### PR TITLE
nit: refactor command structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .env
-elmo
+./elmo
 nohup.out

--- a/cmd/elmo/main.go
+++ b/cmd/elmo/main.go
@@ -6,24 +6,14 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/servusdei2018/elmobot/pkg/commands"
-	"github.com/servusdei2018/elmobot/pkg/handlers"
-
 	"github.com/bwmarrin/discordgo"
+
+	"github.com/servusdei2018/elmobot/pkg/commands"
 )
 
 var (
 	token = flag.String("token", "", "Discord bot token")
-
-	s *discordgo.Session
-
-	commands_ = []*discordgo.ApplicationCommand{
-		commands.Ping,
-	}
-
-	handles_ = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
-		"ping": handlers.Ping,
-	}
+	s     *discordgo.Session
 )
 
 func init() {
@@ -36,7 +26,7 @@ func init() {
 	}
 
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-		if h, ok := handles_[i.ApplicationCommandData().Name]; ok {
+		if h, ok := commands.Handlers[i.ApplicationCommandData().Name]; ok {
 			h(s, i)
 		}
 	})
@@ -52,8 +42,8 @@ func main() {
 	}
 
 	log.Println("adding commands...")
-	registeredCommands := make([]*discordgo.ApplicationCommand, len(commands_))
-	for i, v := range commands_ {
+	registeredCommands := make([]*discordgo.ApplicationCommand, len(commands.Cmds))
+	for i, v := range commands.Cmds {
 		cmd, err := s.ApplicationCommandCreate(s.State.User.ID, "", v)
 		if err != nil {
 			log.Panicf("error creating command '%v': %v", v.Name, err)

--- a/pkg/commands/cmds.go
+++ b/pkg/commands/cmds.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"github.com/bwmarrin/discordgo"
+
+	"github.com/servusdei2018/elmobot/pkg/handlers"
+)
+
+var (
+	Cmds = []*discordgo.ApplicationCommand{
+		Ping,
+	}
+
+	Handlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+		"ping": handlers.Ping,
+	}
+)


### PR DESCRIPTION
In preparation for the implementation of more commands, I have refactored the command and handler maps out of the main package and into `pkg/commands` which will serve as the hierarchical parent for all commands-related data types and functionality.